### PR TITLE
Issue #4 - Enable ability to disable Analytics from Configuration

### DIFF
--- a/DataBrowser/DataBrowser.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/DataBrowser/DataBrowser.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -12,6 +12,7 @@
       <Setting name="RecaptchaPrivateKey" value=""/>
       <Setting name="RecaptchaPublicKey" value=""/>
       <Setting name="RootServiceNamespace" value="OGDI"/>
+      <Setting name="EnableAnalytics" value="true"/>
       <Setting name="DataConnectionString" value="DefaultEndpointsProtocol=https;AccountName=[StorageName];AccountKey=[StorageKey]"/>
       <Setting name="DiagnosticsConnectionString" value="DefaultEndpointsProtocol=https;AccountName=[StorageName];AccountKey=[StorageKey]"/>
     </ConfigurationSettings>

--- a/DataBrowser/DataBrowser.Cloud/ServiceConfiguration.Local.cscfg
+++ b/DataBrowser/DataBrowser.Cloud/ServiceConfiguration.Local.cscfg
@@ -12,6 +12,7 @@
       <Setting name="RecaptchaPrivateKey" value=""/>
       <Setting name="RecaptchaPublicKey" value=""/>
       <Setting name="RootServiceNamespace" value="OGDI"/>
+      <Setting name="EnableAnalytics" value="true"/>
       <Setting name="DataConnectionString" value="DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="/>
       <Setting name="DiagnosticsConnectionString" value="DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="/>
     </ConfigurationSettings>

--- a/DataBrowser/DataBrowser.Cloud/ServiceDefinition.csdef
+++ b/DataBrowser/DataBrowser.Cloud/ServiceDefinition.csdef
@@ -25,6 +25,7 @@
       <Setting name="RecaptchaPrivateKey" />
       <Setting name="RecaptchaPublicKey" />
       <Setting name="RootServiceNamespace" />
+      <Setting name="EnableAnalytics"/>
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="DataBrowserIn" protocol="http" port="80" />

--- a/DataBrowser/DataBrowser.WebRole/Controllers/RequestController.cs
+++ b/DataBrowser/DataBrowser.WebRole/Controllers/RequestController.cs
@@ -79,9 +79,12 @@ namespace Ogdi.InteractiveSdk.Mvc.Controllers
             if (request == null)
                 throw new ApplicationException("Selected request does not exist any more.");
 
-            AnalyticsRepository.RegisterView(Helper.GenerateRequestKey(id),
-                HttpContext.Request.RawUrl,
-                HttpContext.Request.UserHostName);
+            if (SettingsResolver.EnableAnalytics)
+            {
+                AnalyticsRepository.RegisterView(Helper.GenerateRequestKey(id),
+                                                 HttpContext.Request.RawUrl,
+                                                 HttpContext.Request.UserHostName);
+            }
 
             return View(request);
         }

--- a/DataBrowser/DataBrowser.WebRole/DataBrowser.WebRole.csproj
+++ b/DataBrowser/DataBrowser.WebRole/DataBrowser.WebRole.csproj
@@ -128,6 +128,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helper\SettingsResolver.cs" />
     <Compile Include="Helper\Cache.cs" />
     <Compile Include="Helper\HtmlExtender.cs" />
     <Compile Include="Helper\OgdiViewUserControl.cs">

--- a/DataBrowser/DataBrowser.WebRole/Helper/SettingsResolver.cs
+++ b/DataBrowser/DataBrowser.WebRole/Helper/SettingsResolver.cs
@@ -1,0 +1,21 @@
+﻿namespace Ogdi.InteractiveSdk.Mvc
+{
+    using Microsoft.WindowsAzure.ServiceRuntime;
+    using System.Collections.Specialized;
+    using System.Configuration;
+
+    public static class SettingsResolver
+    {
+        public static NameValueCollection Settings = ConfigurationManager.AppSettings;
+
+        public static bool EnableAnalytics
+        {
+            get
+            {
+                return bool.Parse((RoleEnvironment.IsAvailable)
+                       ? RoleEnvironment.GetConfigurationSettingValue("EnableAnalytics")
+                       : Settings["EnableAnalytics"]);
+            }
+        }
+    }
+}

--- a/DataBrowser/DataBrowser.WebRole/Web.config
+++ b/DataBrowser/DataBrowser.WebRole/Web.config
@@ -28,6 +28,7 @@
     <add key = "DefaultSessionContainerName"/>
     <add key="ChartImageHandler" value="storage=memory;deleteAfterServicing=true;"  />
     <add key="Service" value="Ogdi.InteractiveSdk.Mvc.IsdkWindowsAzureStorageProvider, WindowsAzureStorageProvider"/>
+    <add key="EnableAnalytics" value="false"/>
   </appSettings>
 
   <connectionStrings />

--- a/DataService/DataService.WebRole/AppSettings.cs
+++ b/DataService/DataService.WebRole/AppSettings.cs
@@ -34,6 +34,14 @@ namespace Ogdi.DataServices
             get { return RoleEnvironment.GetConfigurationSettingValue("RootServiceNamespace"); }
         }
 
+        public static bool TrackAnalytics
+        {
+            get
+            {
+                return bool.Parse(RoleEnvironment.GetConfigurationSettingValue("EnableAnalytics"));
+            }
+        }
+
         public static string OgdiConfigTableStorageAccountName
         {
             get { return ParseFromConnectionString(ConnectionStringElement.AccountName); }

--- a/DataService/DataService.WebRole/HttpHandlers/V1OgdiTableStorageProxyHttpHandler.cs
+++ b/DataService/DataService.WebRole/HttpHandlers/V1OgdiTableStorageProxyHttpHandler.cs
@@ -93,22 +93,27 @@ namespace Ogdi.DataServices
                 _context = context;
 
                 WebRequest request = (IsAvailableEndpointsRequest)
-                                     ? CreateTableStorageSignedRequest(context,
-                                                                       AppSettings.Account,
-                                                                       AzureTableRequestEntityUrl,
-                                                                       IsAvailableEndpointsRequest)
-                                     : CreateTableStorageSignedRequest(context,
-                                                                       AppSettings.ParseStorageAccount(
-                                                                               AppSettings.EnabledStorageAccounts[OgdiAlias].storageaccountname,
-                                                                               AppSettings.EnabledStorageAccounts[OgdiAlias].storageaccountkey),
-                                                                       AzureTableRequestEntityUrl,
-                                                                       IsAvailableEndpointsRequest);
+                                         ? CreateTableStorageSignedRequest(context,
+                                                                           AppSettings.Account,
+                                                                           AzureTableRequestEntityUrl,
+                                                                           IsAvailableEndpointsRequest)
+                                         : CreateTableStorageSignedRequest(context,
+                                                                           AppSettings.ParseStorageAccount(
+                                                                               AppSettings.EnabledStorageAccounts[
+                                                                                   OgdiAlias].storageaccountname,
+                                                                               AppSettings.EnabledStorageAccounts[
+                                                                                   OgdiAlias].storageaccountkey),
+                                                                           AzureTableRequestEntityUrl,
+                                                                           IsAvailableEndpointsRequest);
 
-                Action<string, string, string> incView = AnalyticsRepository.RegisterView;
-                incView.BeginInvoke(String.Format("{0}||{1}", OgdiAlias, EntitySet),
-                    context.Request.RawUrl,
-                    context.Request.UserHostName,
-                    null, null);
+                if (AppSettings.TrackAnalytics)
+                {
+                    Action<string, string, string> incView = AnalyticsRepository.RegisterView;
+                    incView.BeginInvoke(String.Format("{0}||{1}", OgdiAlias, EntitySet),
+                                        context.Request.RawUrl,
+                                        context.Request.UserHostName,
+                                        null, null);
+                }
 
                 try
                 {


### PR DESCRIPTION
New Configuration Setting can be found in:
- DataBrowser.Cloud/ServiceConfiguration.local.cscfg
- DataBrowser.Cloud/ServiceConfiguration.cloud.cscfg

`<Setting name="EnableAnalytics" value="true"/>`
- DataBrowser.WebRole/Web.config

`<add key="EnableAnalytics" value="false"/>`
